### PR TITLE
Add support for submenus

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
@@ -699,7 +699,7 @@ void function OnModMenuClosed()
 	file.isOpen = false
 }
 
-void function AddModTitle( string modName )
+void function AddModTitle( string modName, int stackPos = 2 )
 {
 	file.currentMod = modName
 	if ( file.conVarList.len() > 0 )
@@ -729,13 +729,13 @@ void function AddModTitle( string modName )
 	botBar.modName = modName
 	botBar.spaceType = eEmptySpaceType.BottomBar
 	file.conVarList.extend( [ topBar, modData, botBar ] )
-	file.setFuncs[ expect string( getstackinfos(2)[ "func" ] ) ] <- false
+	file.setFuncs[ expect string( getstackinfos( stackPos )[ "func" ] ) ] <- false
 }
 
-void function AddModCategory( string catName )
+void function AddModCategory( string catName, int stackPos = 2 )
 {
-	if ( !( getstackinfos(2)[ "func" ] in file.setFuncs ) )
-		throw getstackinfos(2)[ "src" ] + " #" + getstackinfos(2)[ "line" ] + "\nCannot add a category before a mod title!"
+	if ( !( getstackinfos( stackPos )[ "func" ] in file.setFuncs ) )
+		throw getstackinfos( stackPos )[ "src" ] + " #" + getstackinfos( stackPos )[ "line" ] + "\nCannot add a category before a mod title!"
 	if ( file.currentCat != "" )
 	{
 		ConVarData space
@@ -755,13 +755,13 @@ void function AddModCategory( string catName )
 	file.conVarList.append( catData )
 
 	file.currentCat = catName
-	file.setFuncs[ expect string( getstackinfos(2)[ "func" ] ) ] = true
+	file.setFuncs[ expect string( getstackinfos( stackPos )[ "func" ] ) ] = true
 }
 
-void function AddModSettingsButton( string buttonLabel, void functionref() onPress )
+void function AddModSettingsButton( string buttonLabel, void functionref() onPress, int stackPos = 2 )
 {
-	if ( !( getstackinfos(2)[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos(2)[ "func" ] ) ] )
-		throw getstackinfos(2)[ "src" ] + " #" + getstackinfos(2)[ "line" ] + "\nCannot add a button before a category and mod title!"
+	if ( !( getstackinfos( stackPos )[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos( stackPos )[ "func" ] ) ] )
+		throw getstackinfos( stackPos )[ "src" ] + " #" + getstackinfos( stackPos )[ "line" ] + "\nCannot add a button before a category and mod title!"
 
 	ConVarData data
 
@@ -774,10 +774,10 @@ void function AddModSettingsButton( string buttonLabel, void functionref() onPre
 	file.conVarList.append( data )
 }
 
-void function AddConVarSetting( string conVar, string displayName, string type = "" )
+void function AddConVarSetting( string conVar, string displayName, string type = "", int stackPos = 2 )
 {
-	if ( !( getstackinfos(2)[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos(2)[ "func" ] ) ] )
-		throw getstackinfos(2)[ "src" ] + " #" + getstackinfos(2)[ "line" ] + "\nCannot add a setting before a category and mod title!"
+	if ( !( getstackinfos( stackPos )[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos( stackPos )[ "func" ] ) ] )
+		throw getstackinfos( stackPos )[ "src" ] + " #" + getstackinfos( stackPos )[ "line" ] + "\nCannot add a setting before a category and mod title!"
 	ConVarData data
 
 	data.catName = file.currentCat
@@ -789,10 +789,10 @@ void function AddConVarSetting( string conVar, string displayName, string type =
 	file.conVarList.append( data )
 }
 
-void function AddConVarSettingSlider( string conVar, string displayName, float min = 0.0, float max = 1.0, float stepSize = 0.1, bool forceClamp = false )
+void function AddConVarSettingSlider( string conVar, string displayName, float min = 0.0, float max = 1.0, float stepSize = 0.1, bool forceClamp = false, int stackPos = 2 )
 {
-	if ( !( getstackinfos(2)[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos(2)[ "func" ] ) ] )
-		throw getstackinfos(2)[ "src" ] + " #" + getstackinfos(2)[ "line" ] + "\nCannot add a setting before a category and mod title!"
+	if ( !( getstackinfos( stackPos )[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos( stackPos )[ "func" ] ) ] )
+		throw getstackinfos( stackPos )[ "src" ] + " #" + getstackinfos( stackPos )[ "line" ] + "\nCannot add a setting before a category and mod title!"
 	ConVarData data
 
 	data.catName = file.currentCat
@@ -809,10 +809,10 @@ void function AddConVarSettingSlider( string conVar, string displayName, float m
 	file.conVarList.append( data )
 }
 
-void function AddConVarSettingEnum( string conVar, string displayName, array<string> values )
+void function AddConVarSettingEnum( string conVar, string displayName, array<string> values, int stackPos = 2 )
 {
-	if ( !( getstackinfos(2)[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos(2)[ "func" ] ) ] )
-		throw getstackinfos(2)[ "src" ] + " #" + getstackinfos(2)[ "line" ] + "\nCannot add a setting before a category and mod title!"
+	if ( !( getstackinfos( stackPos )[ "func" ] in file.setFuncs ) || !file.setFuncs[ expect string( getstackinfos( stackPos )[ "func" ] ) ] )
+		throw getstackinfos( stackPos )[ "src" ] + " #" + getstackinfos( stackPos )[ "line" ] + "\nCannot add a setting before a category and mod title!"
 	ConVarData data
 
 	data.catName = file.currentCat

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
@@ -79,7 +79,6 @@ void function AddModSettingsMenu()
 void function InitModMenu()
 {
 	file.menu = GetMenu( "ModSettings" )
-	// DumpStack(2)
 	AddMenuFooterOption( file.menu, BUTTON_B, "#B_BUTTON_BACK", "#BACK" )
 
 	/////////////////////////////
@@ -95,8 +94,6 @@ void function InitModMenu()
 	} )
 	AddConVarSettingEnum( "filter_mods", "Very Huge Enum Example", split( "Never gonna give you up Never gonna let you down Never gonna run around and desert you Never gonna make you cry Never gonna say goodbye Never gonna tell a lie and hurt you", " " ) )
 	*/
-	// Nuke weird rui on filter switch :D
-	// RuiSetString( Hud_GetRui( Hud_GetChild( file.menu, "SwtBtnShowFilter" ) ), "buttonText", "" )
 
 	file.modPanels = GetElementsByClassname( file.menu, "ModButton" )
 
@@ -106,8 +103,6 @@ void function InitModMenu()
 	int len = file.modPanels.len()
 	for ( int i = 0; i < len; i++ )
 	{
-
-		// AddButtonEventHandler( button, UIE_CHANGE, OnSettingButtonPressed  )
 		// get panel
 		var panel = file.modPanels[i]
 
@@ -145,7 +140,6 @@ void function InitModMenu()
 
 		Hud_AddEventHandler( child, UIE_CLICK, ResetConVar )
 		file.resetModButtons.append(child)
-		//Hud_AddEventHandler( Hud_GetChild( panel, "ResetModImage" ), UIE_CLICK, ResetConVar )
 
 		// text field nav
 		child = Hud_GetChild( panel, "TextEntrySetting" )
@@ -169,7 +163,6 @@ void function InitModMenu()
 		Hud_AddEventHandler( child, UIE_CLICK, CustomButtonPressed )
 	}
 
-	// Hud_AddEventHandler( Hud_GetChild( file.menu, "BtnModsSearch" ), UIE_LOSE_FOCUS, OnFilterTextPanelChanged )
 	Hud_AddEventHandler( Hud_GetChild( file.menu, "BtnFiltersClear" ), UIE_CLICK, OnClearButtonPressed )
 	// mouse delta
 	AddMouseMovementCaptureHandler( file.menu, UpdateMouseDeltaBuffer )
@@ -457,12 +450,8 @@ array<ConVarData> function GetAllVarsInCategory( array<ConVarData> arr, string c
 		if ( c.catName == catName )
 		{
 			vars.append( arr[i] )
-			// printt( file.conVarList[i].conVar + " is in mod " + file.conVarList[i].modName )
 		}
 	}
-	/*ConVarData empty
-	empty.isEmptySpace = true
-	vars.append( empty )*/
 	return vars
 }
 
@@ -475,12 +464,8 @@ array<ConVarData> function GetAllVarsInMod( array<ConVarData> arr, string modNam
 		if ( c.modName == modName )
 		{
 			vars.append( arr[i] )
-			// printt( file.conVarList[i].conVar + " is in mod " + file.conVarList[i].modName )
 		}
 	}
-	/*ConVarData empty
-	empty.isEmptySpace = true
-	vars.append( empty )*/
 	return vars
 }
 
@@ -565,7 +550,6 @@ void function SetModMenuNameText( var button )
 	else if ( conVar.isModName )
 	{
 		Hud_SetText( modTitle, conVar.modName )
-		// Hud_SetSize( resetButton, 0, int(40 * scaleY) )
 		Hud_SetPos( label, 0, 0 )
 		Hud_SetVisible( label, false )
 		Hud_SetVisible( textField, false )
@@ -578,12 +562,8 @@ void function SetModMenuNameText( var button )
 	else if ( conVar.isCategoryName )
 	{
 		Hud_SetText( label, conVar.catName )
-		// Hud_SetText( resetButton, "#MOD_SETTINGS_RESET_ALL" )
-		// Hud_SetSize( resetButton, int( 120 * scaleX ), int( 40 * scaleY ) )
 		Hud_SetPos( label, 0, 0 )
 		Hud_SetSize( label, int( scaleX * ( 1180 - 420 - 85 ) ), int( scaleY * 40 ) )
-		// Hud_SetSize( customMenuButton, int( 85 * scaleX ), int( 40 * scaleY ) )
-		// Hud_SetVisible( customMenuButton, conVar.hasCustomMenu )
 		Hud_SetVisible( label, true )
 		Hud_SetVisible( textField, false )
 		Hud_SetVisible( enumButton, false )
@@ -706,13 +686,7 @@ void function CheckFocus( var button )
 void function OnFiltersChange( var n )
 {
 	file.scrollOffset = 0
-
-	// HideAllButtons()
-
-	// RefreshModsArray()
-
 	UpdateList()
-
 	UpdateListSliderHeight()
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
@@ -170,7 +170,7 @@ void function InitModMenu()
 	Hud_AddEventHandler( Hud_GetChild( file.menu, "BtnModsSearch" ), UIE_CHANGE, void function ( var inputField ) : ()
 	{
 		file.filterText = Hud_GetUTF8Text( inputField )
-		OnFiltersChange(0)
+		OnFiltersChange()
 	} )
 }
 
@@ -661,7 +661,7 @@ void function OnModMenuOpened()
 		RegisterButtonPressedCallback( MOUSE_WHEEL_UP , OnScrollUp )
 		RegisterButtonPressedCallback( MOUSE_WHEEL_DOWN , OnScrollDown )
 		RegisterButtonPressedCallback( MOUSE_LEFT , OnClick )
-		OnFiltersChange(0)
+		OnFiltersChange()
 		file.isOpen = true
 	}
 }
@@ -681,7 +681,7 @@ void function CheckFocus( var button )
 	}
 }
 
-void function OnFiltersChange( var n )
+void function OnFiltersChange()
 {
 	file.scrollOffset = 0
 	UpdateList()
@@ -1005,7 +1005,7 @@ void function OnClearButtonPressed( var button )
 	file.filterText = ""
 	Hud_SetText( Hud_GetChild( file.menu, "BtnModsSearch" ), "" )
 
-	OnFiltersChange(0)
+	OnFiltersChange()
 }
 
 string function SanitizeDisplayName( string displayName )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
@@ -3,6 +3,7 @@ global function AddModSettingsMenu
 global function AddConVarSetting
 global function AddConVarSettingEnum
 global function AddConVarSettingSlider
+global function AddModSettingsButton
 global function AddModTitle
 global function AddModCategory
 global function PureModulo
@@ -50,6 +51,7 @@ struct {
 	var menu
 	int scrollOffset = 0
 	bool updatingList = false
+	bool isOpen
 
 	array<ConVarData> conVarList
 	// if people use searches - i hate them but it'll do : )
@@ -556,6 +558,7 @@ void function SetModMenuNameText( var button )
 		Hud_SetVisible( enumButton, false )
 		Hud_SetVisible( resetButton, false )
 		Hud_SetVisible( modTitle, false )
+		Hud_SetVisible( resetVGUI, false )
 		Hud_SetVisible( customMenuButton, true )
 		Hud_SetText( customMenuButton, conVar.displayName )
 	}
@@ -673,14 +676,16 @@ void function UpdateListSliderPosition()
 
 void function OnModMenuOpened()
 {
-	file.scrollOffset = 0
-	file.filterText = ""
-
-	RegisterButtonPressedCallback( MOUSE_WHEEL_UP , OnScrollUp )
-	RegisterButtonPressedCallback( MOUSE_WHEEL_DOWN , OnScrollDown )
-	RegisterButtonPressedCallback( MOUSE_LEFT , OnClick )
-
-	OnFiltersChange(0)
+	if( !file.isOpen )
+	{
+		file.scrollOffset = 0
+		file.filterText = ""
+		RegisterButtonPressedCallback( MOUSE_WHEEL_UP , OnScrollUp )
+		RegisterButtonPressedCallback( MOUSE_WHEEL_DOWN , OnScrollDown )
+		RegisterButtonPressedCallback( MOUSE_LEFT , OnClick )
+		OnFiltersChange(0)
+		file.isOpen = true
+	}
 }
 
 void function OnClick( var button )
@@ -713,19 +718,13 @@ void function OnFiltersChange( var n )
 
 void function OnModMenuClosed()
 {
-	try
-	{
-		DeregisterButtonPressedCallback( MOUSE_WHEEL_UP , OnScrollUp )
-		DeregisterButtonPressedCallback( MOUSE_WHEEL_DOWN , OnScrollDown )
-		DeregisterButtonPressedCallback( MOUSE_LEFT , OnClick )
-		// DeregisterButtonPressedCallback( KEY_F1 , ToggleHideMenu )
-	}
-	catch ( ex ) {}
+	DeregisterButtonPressedCallback( MOUSE_WHEEL_UP , OnScrollUp )
+	DeregisterButtonPressedCallback( MOUSE_WHEEL_DOWN , OnScrollDown )
+	DeregisterButtonPressedCallback( MOUSE_LEFT , OnClick )
 
 	file.scrollOffset = 0
-	// UI_SetPresentationType( ePresentationType.DEFAULT )
-	// SetBlurEnabled( !IsMultiplayer() )
-	// Hud_SetVisible( file.menu, false )
+	UpdateListSliderPosition()
+	file.isOpen = false
 }
 
 void function AddModTitle( string modName )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
@@ -283,10 +283,8 @@ void function SliderBarUpdate()
 
 	float jump = minYPos - ( useableSpace / ( float( file.filteredList.len() ) ) )
 
-	// got local from official respaw scripts, without untyped throws an error
-
-	local pos =	Hud_GetPos( sliderButton )[1]
-	local newPos = pos - mouseDeltaBuffer.deltaY
+	float yPos = float( expect int( Hud_GetPos( sliderButton )[1] ) )
+	float newPos = yPos - mouseDeltaBuffer.deltaY
 	FlushMouseDeltaBuffer()
 
 	if ( newPos < maxYPos ) newPos = maxYPos


### PR DESCRIPTION
* the menu now doesn't get refreshed when exiting a submenu opened by a modsettings button
* removed code that was commented out
* hide reset VGUI on buttons
* make modsettings button function global to allow other mods to use them
* replace `local` with types 
* remove an unnecessary parameter in `OnFiltersChange`
* allow for more control when adding mod settings. It's still impossible to add settings to other mods, but it's now possible to define utilities if needed.